### PR TITLE
修正: 如果指定了参数，会被配置文件的值覆盖

### DIFF
--- a/structarg.go
+++ b/structarg.go
@@ -56,6 +56,7 @@ type Argument interface {
 	DoAction() error
 	Validate() error
 	SetDefault()
+	IsSet() bool
 }
 
 type SingleArgument struct {
@@ -589,6 +590,10 @@ func (this *SingleArgument) Validate() error {
 	return nil
 }
 
+func (this *SingleArgument) IsSet() bool {
+	return this.isSet
+}
+
 func (this *MultiArgument) IsMulti() bool {
 	return true
 }
@@ -912,6 +917,9 @@ func isQuoted(str string) bool {
 func (this *ArgumentParser) parseKeyValue(key, value string) error {
 	arg := this.findOptionalArgument(key, true)
 	if arg != nil {
+		if arg.IsSet() {
+			return nil
+		}
 		if arg.IsMulti() {
 			if value[0] == '(' {
 				value = strings.Trim(value, "()")
@@ -1009,6 +1017,9 @@ func (this *ArgumentParser) parseJSONKeyValue(key string, obj jsonutils.JSONObje
 		log.Warningf("Cannot find argument %s", token)
 		return nil
 	}
+	if arg.IsSet() {
+		return nil
+	}
 	// process multi argument
 	if arg.IsMulti() {
 		array, ok := obj.(*jsonutils.JSONArray)
@@ -1042,7 +1053,7 @@ func (this *ArgumentParser) ParseFile(filepath string) error {
 }
 
 func (this *ArgumentParser) parseReader(r io.Reader) error {
-		scanner := bufio.NewScanner(r)
+	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
 		line := scanner.Text()
 		line = strings.TrimSpace(removeComments(line))


### PR DESCRIPTION
**这个 PR 实现什么功能/修复什么问题**:

修复: 一个参数同时在命令行和配置文件中指定，配置文件中的值会覆盖命令行指定的值

/cc @swordqiu @yousong 